### PR TITLE
Show project sessions on project show page

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,8 +9,8 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    # TODO: Enable when Session model has project association
-    # @sessions = @project.sessions.includes(:swarm_template).order(created_at: :desc)
+    # Only show active sessions on project show page
+    @sessions = @project.sessions.active.order(started_at: :desc)
 
     respond_to do |format|
       format.html

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -263,21 +263,34 @@
     <% end %>
 
     <div class="mt-8">
-      <h2 class="text-base font-semibold leading-6 text-gray-900 dark:text-gray-100 mb-4">Sessions</h2>
-      
-      <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-8 text-center border-2 border-dashed border-gray-300 dark:border-gray-700">
-        <div class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500">
-          <%= heroicon "command-line", variant: :outline, options: { class: "h-12 w-12" } %>
-        </div>
-        <h3 class="mt-2 text-sm font-semibold text-gray-900 dark:text-gray-100">Session association coming soon</h3>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Sessions will be displayed here once the association is implemented.</p>
-        <div class="mt-6">
-          <%= link_to new_session_path(project_id: @project.id), class: "inline-flex items-center rounded-md bg-orange-900 dark:bg-orange-900 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-800 dark:hover:bg-orange-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-900 dark:focus-visible:outline-orange-900 transition-colors duration-200" do %>
-            <%= heroicon "plus", variant: :mini, options: { class: "h-4 w-4 mr-1" } %>
-            Create Session
+      <div class="sm:flex sm:items-center sm:justify-between mb-4">
+        <h2 class="text-base font-semibold leading-6 text-gray-900 dark:text-gray-100">Active Sessions</h2>
+        <div class="mt-3 sm:mt-0">
+          <%= link_to sessions_path(project_id: @project.id), class: "text-sm text-orange-600 dark:text-orange-400 hover:text-orange-700 dark:hover:text-orange-300" do %>
+            View all sessions →
           <% end %>
         </div>
       </div>
+      
+      <% if @sessions.any? %>
+        <div class="space-y-4">
+          <%= render partial: "sessions/session", collection: @sessions %>
+        </div>
+      <% else %>
+        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-8 text-center border-2 border-dashed border-gray-300 dark:border-gray-700">
+          <div class="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500">
+            <%= heroicon "command-line", variant: :outline, options: { class: "h-12 w-12" } %>
+          </div>
+          <h3 class="mt-2 text-sm font-semibold text-gray-900 dark:text-gray-100">No active sessions</h3>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Sessions running for this project will appear here.</p>
+          <div class="mt-6">
+            <%= link_to new_session_path(project_id: @project.id), class: "inline-flex items-center rounded-md bg-orange-900 dark:bg-orange-900 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-orange-800 dark:hover:bg-orange-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-900 dark:focus-visible:outline-orange-900 transition-colors duration-200" do %>
+              <%= heroicon "plus", variant: :mini, options: { class: "h-4 w-4 mr-1" } %>
+              Create Session
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/sessions/_session.html.erb
+++ b/app/views/sessions/_session.html.erb
@@ -1,0 +1,93 @@
+<div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
+  <div class="flex items-center justify-between">
+    <div class="flex items-start space-x-8 flex-1">
+      <div class="min-w-0">
+        <div class="flex items-center space-x-3">
+          <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            <%= session.swarm_name || "Session #{session.id}" %>
+          </h3>
+          <span class="inline-flex items-center rounded-md <%= session.status == 'active' ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 ring-green-600/20 dark:ring-green-400/30' : (session.status == 'stopped' ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 ring-blue-600/20 dark:ring-blue-400/30' : 'bg-gray-50 dark:bg-gray-900/30 text-gray-700 dark:text-gray-400 ring-gray-600/20 dark:ring-gray-400/30') %> px-2 py-1 text-xs font-medium ring-1 ring-inset flex-shrink-0">
+            <%= heroicon session.status == 'active' ? 'play' : (session.status == 'stopped' ? 'stop' : 'archive-box'), variant: :mini, options: { class: "h-3 w-3 mr-1" } %>
+            <%= session.status&.capitalize || 'Unknown' %>
+          </span>
+        </div>
+        <% if session.project.present? %>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate" title="<%= session.project.path %>">
+            <span class="font-semibold">Project:</span> <%= session.project.name %> (<%= session.project.path %>)
+          </p>
+        <% end %>
+        <% if session.configuration_path.present? %>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate" title="<%= session.configuration_path %>">
+            <span class="font-semibold">Config:</span> <%= session.configuration_path %>
+          </p>
+        <% end %>
+        <% if session.swarm_name.present? %>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            <span class="font-semibold">Swarm:</span> <%= session.swarm_name %>
+          </p>
+        <% end %>
+      </div>
+      
+      <div class="flex items-center space-x-6 text-sm text-gray-600 dark:text-gray-400">
+        <div>
+          <% start_time = session.resumed_at || session.started_at %>
+          <span class="font-medium"><%= session.resumed_at ? "Resumed:" : "Started:" %></span> <%= start_time&.strftime("%b %d, %I:%M %p") || "Not started" %>
+        </div>
+        <% if session.duration_seconds.present? %>
+          <div>
+            <span class="font-medium">Duration:</span> <%= distance_of_time_in_words(session.duration_seconds) %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="flex items-center space-x-2 ml-4 flex-shrink-0">
+      <% unless session.status == 'archived' %>
+        <%= link_to session_path(session), class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors duration-200", title: session.status == 'active' ? 'Attach' : 'Resume' do %>
+          <%= heroicon session.status == 'active' ? 'command-line' : 'play', variant: session.status == 'active' ? :solid : :mini, options: { class: "h-4 w-4 mr-1.5" } %>
+          <%= session.status == 'active' ? 'Attach' : 'Resume' %>
+        <% end %>
+      <% end %>
+      <%= link_to clone_session_path(session), 
+          class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-600 dark:text-gray-300 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors duration-200", 
+          title: "Use this session as a template for a new session" do %>
+        <%= heroicon "document-duplicate", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
+        Use as template
+      <% end %>
+      <% if session.status == 'active' %>
+        <%= link_to kill_session_path(session), 
+            data: { 
+              "turbo-method": "post",
+              "turbo-confirm": "Are you sure you want to kill this session?"
+            }, 
+            class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-red-600 dark:text-red-400 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-700 dark:hover:text-red-300 transition-colors duration-200", 
+            title: "Kill session" do %>
+          <%= heroicon "x-circle", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
+          Kill
+        <% end %>
+      <% elsif session.status == 'stopped' %>
+        <%= link_to archive_session_path(session), 
+            data: { 
+              "turbo-method": "post",
+              "turbo-confirm": "Are you sure you want to archive this session?"
+            }, 
+            class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-600 dark:text-gray-300 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors duration-200", 
+            title: "Archive session" do %>
+          <%= heroicon "archive-box", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
+          Archive
+        <% end %>
+      <% elsif session.status == 'archived' %>
+        <%= link_to unarchive_session_path(session), 
+            data: { 
+              "turbo-method": "post",
+              "turbo-confirm": "Are you sure you want to unarchive this session?"
+            }, 
+            class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-blue-600 dark:text-blue-400 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-700 dark:hover:text-blue-300 transition-colors duration-200", 
+            title: "Unarchive session" do %>
+          <%= heroicon "arrow-uturn-left", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
+          Unarchive
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -18,28 +18,49 @@
       </div>
     </div>
 
+    <!-- Project Filter -->
+    <div class="mt-6">
+      <div class="sm:flex sm:items-center sm:justify-between">
+        <div class="w-full sm:max-w-xs">
+          <label for="project-filter" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Filter by project</label>
+          <select id="project-filter" 
+                  name="project_id" 
+                  class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 py-2 pl-3 pr-10 text-base text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 focus:border-orange-500 dark:focus:border-orange-400 focus:outline-none focus:ring-orange-500 dark:focus:ring-orange-400 sm:text-sm"
+                  onchange="filterByProject(this.value)">
+            <option value="">All projects</option>
+            <% @projects.each do |project| %>
+              <option value="<%= project.id %>" <%= 'selected' if @project_id == project.id.to_s %>>
+                <%= project.name %> (<%= project.sessions.count %> sessions)
+              </option>
+            <% end %>
+          </select>
+        </div>
+      </div>
+    </div>
+
     <!-- Tabs -->
     <div class="mt-8">
       <div class="border-b border-gray-200 dark:border-gray-700">
         <nav class="-mb-px flex space-x-8" aria-label="Tabs">
-          <%= link_to sessions_path(filter: 'active'), class: "#{@filter == 'active' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
+          <% tab_params = @project_id.present? ? { project_id: @project_id } : {} %>
+          <%= link_to sessions_path(tab_params.merge(filter: 'active')), class: "#{@filter == 'active' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
             <%= heroicon "play", variant: :mini, options: { class: "h-4 w-4 inline mr-1" } %>
             Active
-            <span class="ml-2 rounded-full <%= @filter == 'active' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= Session.active.count %></span>
+            <span class="ml-2 rounded-full <%= @filter == 'active' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= @project_id.present? ? @sessions.active.count : Session.active.count %></span>
           <% end %>
-          <%= link_to sessions_path(filter: 'stopped'), class: "#{@filter == 'stopped' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
+          <%= link_to sessions_path(tab_params.merge(filter: 'stopped')), class: "#{@filter == 'stopped' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
             <%= heroicon "stop", variant: :mini, options: { class: "h-4 w-4 inline mr-1" } %>
             Stopped
-            <span class="ml-2 rounded-full <%= @filter == 'stopped' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= Session.stopped.count %></span>
+            <span class="ml-2 rounded-full <%= @filter == 'stopped' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= @project_id.present? ? Session.where(project_id: @project_id).stopped.count : Session.stopped.count %></span>
           <% end %>
-          <%= link_to sessions_path(filter: 'archived'), class: "#{@filter == 'archived' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
+          <%= link_to sessions_path(tab_params.merge(filter: 'archived')), class: "#{@filter == 'archived' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
             <%= heroicon "archive-box", variant: :mini, options: { class: "h-4 w-4 inline mr-1" } %>
             Archived
-            <span class="ml-2 rounded-full <%= @filter == 'archived' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= Session.archived.count %></span>
+            <span class="ml-2 rounded-full <%= @filter == 'archived' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= @project_id.present? ? Session.where(project_id: @project_id).archived.count : Session.archived.count %></span>
           <% end %>
-          <%= link_to sessions_path(filter: 'all'), class: "#{@filter == 'all' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
+          <%= link_to sessions_path(tab_params.merge(filter: 'all')), class: "#{@filter == 'all' ? 'border-orange-900 dark:border-orange-500 text-orange-900 dark:text-orange-400' : 'border-transparent text-gray-500 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-600 hover:text-gray-700 dark:hover:text-gray-200'} whitespace-nowrap border-b-2 py-2 px-1 text-sm font-medium transition-colors duration-200" do %>
             All
-            <span class="ml-2 rounded-full <%= @filter == 'all' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= Session.count %></span>
+            <span class="ml-2 rounded-full <%= @filter == 'all' ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-900 dark:text-orange-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400' %> px-2.5 py-0.5 text-xs font-medium"><%= @project_id.present? ? Session.where(project_id: @project_id).count : Session.count %></span>
           <% end %>
         </nav>
       </div>
@@ -47,101 +68,7 @@
 
     <% if @sessions.any? %>
       <div class="mt-8 space-y-4">
-        <% @sessions.each do |session| %>
-          <div class="bg-white dark:bg-gray-800 shadow dark:shadow-gray-700/50 rounded-lg p-6 border border-gray-200 dark:border-gray-700 transition-colors duration-200">
-            <div class="flex items-center justify-between">
-              <div class="flex items-start space-x-8 flex-1">
-                <div class="min-w-0">
-                  <div class="flex items-center space-x-3">
-                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-                      <%= session.swarm_name || "Session #{session.id}" %>
-                    </h3>
-                    <span class="inline-flex items-center rounded-md <%= session.status == 'active' ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 ring-green-600/20 dark:ring-green-400/30' : (session.status == 'stopped' ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 ring-blue-600/20 dark:ring-blue-400/30' : 'bg-gray-50 dark:bg-gray-900/30 text-gray-700 dark:text-gray-400 ring-gray-600/20 dark:ring-gray-400/30') %> px-2 py-1 text-xs font-medium ring-1 ring-inset flex-shrink-0">
-                      <%= heroicon session.status == 'active' ? 'play' : (session.status == 'stopped' ? 'stop' : 'archive-box'), variant: :mini, options: { class: "h-3 w-3 mr-1" } %>
-                      <%= session.status&.capitalize || 'Unknown' %>
-                    </span>
-                  </div>
-                  <% if session.project.present? %>
-                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate" title="<%= session.project.path %>">
-                      <span class="font-semibold">Project:</span> <%= session.project.name %> (<%= session.project.path %>)
-                    </p>
-                  <% end %>
-                  <% if session.configuration_path.present? %>
-                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate" title="<%= session.configuration_path %>">
-                      <span class="font-semibold">Config:</span> <%= session.configuration_path %>
-                    </p>
-                  <% end %>
-                  <% if session.swarm_name.present? %>
-                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                      <span class="font-semibold">Swarm:</span> <%= session.swarm_name %>
-                    </p>
-                  <% end %>
-                </div>
-                
-                <div class="flex items-center space-x-6 text-sm text-gray-600 dark:text-gray-400">
-                  <div>
-                    <% start_time = session.resumed_at || session.started_at %>
-                    <span class="font-medium"><%= session.resumed_at ? "Resumed:" : "Started:" %></span> <%= start_time&.strftime("%b %d, %I:%M %p") || "Not started" %>
-                  </div>
-                  <% if session.duration_seconds.present? %>
-                    <div>
-                      <span class="font-medium">Duration:</span> <%= distance_of_time_in_words(session.duration_seconds) %>
-                    </div>
-                  <% end %>
-                </div>
-              </div>
-
-              <div class="flex items-center space-x-2 ml-4 flex-shrink-0">
-                <% unless session.status == 'archived' %>
-                  <%= link_to session_path(session), class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-100 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors duration-200", title: session.status == 'active' ? 'Attach' : 'Resume' do %>
-                    <%= heroicon session.status == 'active' ? 'command-line' : 'play', variant: session.status == 'active' ? :solid : :mini, options: { class: "h-4 w-4 mr-1.5" } %>
-                    <%= session.status == 'active' ? 'Attach' : 'Resume' %>
-                  <% end %>
-                <% end %>
-                <%= link_to clone_session_path(session), 
-                    class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-600 dark:text-gray-300 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors duration-200", 
-                    title: "Use this session as a template for a new session" do %>
-                  <%= heroicon "document-duplicate", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
-                  Use as template
-                <% end %>
-                <% if session.status == 'active' %>
-                  <%= link_to kill_session_path(session), 
-                      data: { 
-                        "turbo-method": "post",
-                        "turbo-confirm": "Are you sure you want to kill this session?"
-                      }, 
-                      class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-red-600 dark:text-red-400 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-700 dark:hover:text-red-300 transition-colors duration-200", 
-                      title: "Kill session" do %>
-                    <%= heroicon "x-circle", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
-                    Kill
-                  <% end %>
-                <% elsif session.status == 'stopped' %>
-                  <%= link_to archive_session_path(session), 
-                      data: { 
-                        "turbo-method": "post",
-                        "turbo-confirm": "Are you sure you want to archive this session?"
-                      }, 
-                      class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-gray-600 dark:text-gray-300 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors duration-200", 
-                      title: "Archive session" do %>
-                    <%= heroicon "archive-box", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
-                    Archive
-                  <% end %>
-                <% elsif session.status == 'archived' %>
-                  <%= link_to unarchive_session_path(session), 
-                      data: { 
-                        "turbo-method": "post",
-                        "turbo-confirm": "Are you sure you want to unarchive this session?"
-                      }, 
-                      class: "inline-flex items-center justify-center rounded-md bg-white dark:bg-gray-700 px-3 py-2 text-sm font-semibold text-blue-600 dark:text-blue-400 shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-600 hover:bg-blue-50 dark:hover:bg-blue-900/20 hover:text-blue-700 dark:hover:text-blue-300 transition-colors duration-200", 
-                      title: "Unarchive session" do %>
-                    <%= heroicon "arrow-uturn-left", variant: :mini, options: { class: "h-4 w-4 mr-1.5" } %>
-                    Unarchive
-                  <% end %>
-                <% end %>
-              </div>
-            </div>
-          </div>
-        <% end %>
+        <%= render partial: "session", collection: @sessions %>
       </div>
     <% else %>
       <div class="mt-8 text-center">
@@ -162,3 +89,22 @@
     <% end %>
   </div>
 </div>
+
+<script>
+  function filterByProject(projectId) {
+    const currentFilter = '<%= @filter %>';
+    const params = new URLSearchParams();
+    
+    if (currentFilter !== 'active') {
+      params.append('filter', currentFilter);
+    }
+    
+    if (projectId) {
+      params.append('project_id', projectId);
+    }
+    
+    const queryString = params.toString();
+    const url = '<%= sessions_path %>' + (queryString ? '?' + queryString : '');
+    window.location.href = url;
+  }
+</script>


### PR DESCRIPTION
## Summary
- Display only active sessions on project show page
- Add project filter dropdown to sessions index page
- Extract session display into reusable partial

## Changes
1. **Project Show Page**
   - Shows only active sessions for the project
   - Adds "View all sessions" link that navigates to sessions index with project filter applied
   - Displays empty state when no active sessions

2. **Sessions Index Page**
   - Added project filter dropdown to filter sessions by project
   - Updated tab navigation to preserve project filter when switching between status filters
   - Tab counts now reflect filtered results when a project is selected

3. **Code Refactoring**
   - Extracted session display into `app/views/sessions/_session.html.erb` partial
   - Reused partial in both sessions index and project show views
   - Updated controllers to support project filtering

## Fixes #10

## Test Plan
- [ ] Project show page displays only active sessions
- [ ] "View all sessions" link works and applies project filter
- [ ] Project filter dropdown on sessions index filters correctly
- [ ] Tab navigation preserves project filter
- [ ] Tab counts reflect filtered results
- [ ] Session cards display correctly in both views