### PR TITLE
Make session names clickable with context-aware behavior

### DIFF
--- a/app/views/sessions/_session.html.erb
+++ b/app/views/sessions/_session.html.erb
@@ -4,7 +4,11 @@
       <div class="min-w-0">
         <div class="flex items-center space-x-3">
           <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">
-            <%= session.swarm_name || "Session #{session.id}" %>
+            <% if session.status == 'active' %>
+              <%= link_to session.swarm_name || "Session #{session.id}", session_path(session), class: "hover:text-orange-900 dark:hover:text-orange-400 transition-colors duration-200" %>
+            <% else %>
+              <%= link_to session.swarm_name || "Session #{session.id}", session_path(session, view_only: true), class: "hover:text-orange-900 dark:hover:text-orange-400 transition-colors duration-200" %>
+            <% end %>
           </h3>
           <span class="inline-flex items-center rounded-md <%= session.status == 'active' ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-400 ring-green-600/20 dark:ring-green-400/30' : (session.status == 'stopped' ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 ring-blue-600/20 dark:ring-blue-400/30' : 'bg-gray-50 dark:bg-gray-900/30 text-gray-700 dark:text-gray-400 ring-gray-600/20 dark:ring-gray-400/30') %> px-2 py-1 text-xs font-medium ring-1 ring-inset flex-shrink-0">
             <%= heroicon session.status == 'active' ? 'play' : (session.status == 'stopped' ? 'stop' : 'archive-box'), variant: :mini, options: { class: "h-3 w-3 mr-1" } %>


### PR DESCRIPTION
## Summary
- Made session names clickable links in the sessions index
- Active sessions link directly to attach/terminal view
- Non-active sessions link to info view with `view_only=true`
- Added hover effect with orange color for better UX

## Test plan
- [ ] Click on an active session name - should attach to terminal
- [ ] Click on a stopped session name - should show session info
- [ ] Click on an archived session name - should show session info
- [ ] Verify hover effect changes text color to orange

🤖 Generated with [Claude Code](https://claude.ai/code)