### PR TITLE
Add hover dropdown for active sessions in navbar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :set_theme_class
   before_action :check_version_update
 
-  helper_method :dark_mode?, :update_available?
+  helper_method :dark_mode?, :update_available?, :active_sessions
 
   private
 
@@ -36,5 +36,9 @@ class ApplicationController < ActionController::Base
   def update_available?
     # Always fetch fresh instance to ensure we have latest data
     VersionChecker.instance.update_available?
+  end
+
+  def active_sessions
+    @active_sessions ||= Session.active.recent
   end
 end

--- a/app/javascript/controllers/dropdown_hover_controller.js
+++ b/app/javascript/controllers/dropdown_hover_controller.js
@@ -1,0 +1,70 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="dropdown-hover"
+export default class extends Controller {
+  static targets = ["menu", "trigger"]
+  static values = { 
+    hasItems: Boolean,
+    clickable: { type: Boolean, default: true }
+  }
+  
+  connect() {
+    this.hideTimeout = null
+    this.isHovering = false
+  }
+  
+  disconnect() {
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout)
+    }
+  }
+  
+  show() {
+    if (!this.hasItemsValue || !this.hasMenuTarget) return
+    
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout)
+      this.hideTimeout = null
+    }
+    
+    this.isHovering = true
+    this.menuTarget.classList.remove("hidden")
+  }
+  
+  hide() {
+    this.isHovering = false
+    
+    // Small delay to allow moving cursor from trigger to menu
+    this.hideTimeout = setTimeout(() => {
+      if (!this.isHovering && this.hasMenuTarget) {
+        this.menuTarget.classList.add("hidden")
+      }
+    }, 100)
+  }
+  
+  menuEnter() {
+    this.isHovering = true
+    if (this.hideTimeout) {
+      clearTimeout(this.hideTimeout)
+      this.hideTimeout = null
+    }
+  }
+  
+  menuLeave() {
+    this.hide()
+  }
+  
+  // Prevent dropdown from closing when clicking inside menu items
+  menuClick(event) {
+    // Don't stop propagation, just prevent the dropdown from closing
+    this.isHovering = true
+  }
+  
+  // Handle trigger click
+  triggerClick(event) {
+    if (!this.clickableValue) {
+      event.preventDefault()
+    }
+    // If clickable is true, allow default behavior (navigation)
+  }
+}

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,10 +10,46 @@
       
       <!-- Main Navigation -->
       <div class="hidden md:flex items-center space-x-6">
-<%= link_to sessions_path, class: "flex items-center px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-orange-900 dark:hover:text-orange-400 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md transition-colors duration-200 #{'bg-orange-50 dark:bg-orange-900/20 text-orange-900 dark:text-orange-400' if current_page?(sessions_path) || (params[:controller] == 'sessions' && action_name != 'show')}" do %>
-          <%= heroicon "command-line", variant: :outline, options: { class: "h-4 w-4 mr-1" } %>
-          Sessions
-        <% end %>
+<div class="relative" data-controller="dropdown-hover" data-dropdown-hover-has-items-value="<%= active_sessions.any? %>">
+          <%= link_to sessions_path, 
+              class: "flex items-center px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-orange-900 dark:hover:text-orange-400 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md transition-colors duration-200 #{'bg-orange-50 dark:bg-orange-900/20 text-orange-900 dark:text-orange-400' if current_page?(sessions_path) || (params[:controller] == 'sessions' && action_name != 'show')}",
+              data: { 
+                "dropdown-hover-target": "trigger",
+                action: "mouseenter->dropdown-hover#show mouseleave->dropdown-hover#hide click->dropdown-hover#triggerClick"
+              } do %>
+            <%= heroicon "command-line", variant: :outline, options: { class: "h-4 w-4 mr-1" } %>
+            Sessions
+          <% end %>
+          
+          <% if active_sessions.any? %>
+            <div class="absolute left-0 mt-1 w-64 bg-white dark:bg-gray-800 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 hidden z-50"
+                 data-dropdown-hover-target="menu"
+                 data-action="mouseenter->dropdown-hover#menuEnter mouseleave->dropdown-hover#menuLeave click->dropdown-hover#menuClick">
+              <div class="py-1">
+                <% active_sessions.each do |session| %>
+                  <%= link_to session_path(session),
+                      class: "block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-gray-100 transition-colors duration-150",
+                      data: { turbo_frame: "_top" } do %>
+                    <div class="flex items-center justify-between">
+                      <div class="flex items-center space-x-2">
+                        <%= heroicon "command-line", variant: :solid, options: { class: "h-4 w-4 text-orange-600 dark:text-orange-400" } %>
+                        <span class="font-medium"><%= session.swarm_name %></span>
+                      </div>
+                      <span class="text-xs text-gray-500 dark:text-gray-400">
+                        <%= time_ago_in_words(session.started_at) %> ago
+                      </span>
+                    </div>
+                    <% if session.project.present? %>
+                      <div class="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
+                        <%= session.project.name %>
+                      </div>
+                    <% end %>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
         
         <%= link_to projects_path, class: "flex items-center px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-orange-900 dark:hover:text-orange-400 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md transition-colors duration-200 #{'bg-orange-50 dark:bg-orange-900/20 text-orange-900 dark:text-orange-400' if current_page?(projects_path) || params[:controller] == 'projects'}" do %>
           <%= heroicon "folder", variant: :outline, options: { class: "h-4 w-4 mr-1" } %>
@@ -85,6 +121,11 @@
 <%= link_to sessions_path, class: "flex items-center px-3 py-2 text-base font-medium text-gray-700 dark:text-gray-300 hover:text-orange-900 dark:hover:text-orange-400 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md #{'bg-orange-50 dark:bg-orange-900/20 text-orange-900 dark:text-orange-400' if current_page?(sessions_path) || params[:controller] == 'sessions'}" do %>
         <%= heroicon "command-line", variant: :outline, options: { class: "h-5 w-5 mr-2" } %>
         Sessions
+        <% if active_sessions.any? %>
+          <span class="ml-auto text-xs bg-orange-600 text-white px-2 py-0.5 rounded-full">
+            <%= active_sessions.count %>
+          </span>
+        <% end %>
       <% end %>
       
       <%= link_to projects_path, class: "flex items-center px-3 py-2 text-base font-medium text-gray-700 dark:text-gray-300 hover:text-orange-900 dark:hover:text-orange-400 hover:bg-gray-50 dark:hover:bg-gray-700 rounded-md #{'bg-orange-50 dark:bg-orange-900/20 text-orange-900 dark:text-orange-400' if current_page?(projects_path) || params[:controller] == 'projects'}" do %>


### PR DESCRIPTION
## Summary
- Implemented a hover dropdown menu that shows active sessions when hovering over the Sessions link in the navbar
- The dropdown only appears when there are active sessions
- Sessions link remains clickable and navigates to the sessions index page

## Implementation Details
- Created `dropdown_hover_controller.js` Stimulus controller to handle hover behavior with proper mouse enter/leave logic
- Added `active_sessions` helper method in ApplicationController to fetch active sessions
- Updated navbar with dropdown markup that displays session details (name, time since started, project)
- Added session count badge in mobile menu for better mobile UX
- Clicking on sessions in the dropdown navigates to the session show page (attaching to the session)

## Test plan
- [x] Verify hover dropdown appears when there are active sessions
- [x] Verify no dropdown appears when there are no active sessions
- [x] Verify clicking Sessions link navigates to sessions index
- [x] Verify clicking dropdown items navigates to individual sessions
- [x] Verify mobile menu shows session count badge
- [x] Run rubocop and fix any style issues
- [x] Run test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)