### PR TITLE
Add git diff modal for viewing repository changes

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -62,3 +62,35 @@ iframe::-webkit-scrollbar {
 [data-log-expansion-target="entry"]:hover {
   background-color: rgba(255, 255, 255, 0.02);
 }
+
+/* Diff2html dark mode overrides */
+.dark .d2h-wrapper {
+  color: #e5e7eb;
+}
+
+.dark .d2h-diff-tbody tr {
+  background-color: #1f2937;
+}
+
+.dark .d2h-diff-tbody tr:hover {
+  background-color: #374151;
+}
+
+.dark .d2h-code-line-ctn {
+  background-color: #1f2937;
+}
+
+.dark .d2h-file-header {
+  background-color: #111827;
+  border-color: #374151;
+}
+
+.dark .d2h-file-wrapper {
+  border-color: #374151;
+}
+
+.dark .d2h-code-linenumber {
+  background-color: #111827;
+  color: #6b7280;
+  border-color: #374151;
+}

--- a/app/javascript/controllers/git_diff_modal_controller.js
+++ b/app/javascript/controllers/git_diff_modal_controller.js
@@ -1,0 +1,87 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "content", "loading"]
+
+  connect() {
+    this.boundCloseOnEscape = this.closeOnEscape.bind(this)
+    this.boundCloseOnClickOutside = this.closeOnClickOutside.bind(this)
+  }
+
+  disconnect() {
+    document.removeEventListener("keydown", this.boundCloseOnEscape)
+    document.removeEventListener("click", this.boundCloseOnClickOutside)
+  }
+
+  async open(event) {
+    event.preventDefault()
+    
+    const directory = event.currentTarget.dataset.directory
+    const instanceName = event.currentTarget.dataset.instanceName
+    const sessionId = event.currentTarget.dataset.sessionId
+    
+    this.modalTarget.classList.remove("hidden")
+    this.loadingTarget.classList.remove("hidden")
+    this.contentTarget.innerHTML = ""
+    
+    document.addEventListener("keydown", this.boundCloseOnEscape)
+    document.addEventListener("click", this.boundCloseOnClickOutside)
+    
+    try {
+      const response = await fetch(`/sessions/${sessionId}/git_diff`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": document.querySelector('[name="csrf-token"]').content
+        },
+        body: JSON.stringify({ directory, instance_name: instanceName })
+      })
+      
+      if (response.ok) {
+        const data = await response.json()
+        this.loadingTarget.classList.add("hidden")
+        this.contentTarget.innerHTML = data.html
+        
+        // Initialize diff2html UI if available
+        if (typeof Diff2HtmlUI !== 'undefined' && this.contentTarget.querySelector('#diff')) {
+          const targetElement = this.contentTarget.querySelector('#diff')
+          const configuration = {
+            drawFileList: true,
+            fileListToggle: true,
+            fileListStartVisible: false,
+            synchronisedScroll: true,
+            highlightCode: true
+          }
+          const diff2htmlUi = new Diff2HtmlUI(targetElement, data.diff, configuration)
+          diff2htmlUi.draw()
+          diff2htmlUi.highlightCode()
+        }
+      } else {
+        this.loadingTarget.classList.add("hidden")
+        this.contentTarget.innerHTML = '<div class="text-red-600 dark:text-red-400">Error loading diff</div>'
+      }
+    } catch (error) {
+      this.loadingTarget.classList.add("hidden")
+      this.contentTarget.innerHTML = '<div class="text-red-600 dark:text-red-400">Error loading diff</div>'
+    }
+  }
+
+  close(event) {
+    if (event) event.preventDefault()
+    this.modalTarget.classList.add("hidden")
+    document.removeEventListener("keydown", this.boundCloseOnEscape)
+    document.removeEventListener("click", this.boundCloseOnClickOutside)
+  }
+
+  closeOnEscape(event) {
+    if (event.key === "Escape") {
+      this.close()
+    }
+  }
+
+  closeOnClickOutside(event) {
+    if (this.modalTarget.contains(event.target) && !this.contentTarget.contains(event.target)) {
+      this.close()
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,11 +20,6 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
-    
-    <%# diff2html CSS dependencies %>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html@3.4.47/bundles/css/diff2html.min.css">
-    
     <%= javascript_importmap_tags %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,11 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    
+    <%# diff2html CSS dependencies %>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html@3.4.47/bundles/css/diff2html.min.css">
+    
     <%= javascript_importmap_tags %>
   </head>
 

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -1,5 +1,11 @@
 <% content_for :title, "Session" %>
 
+<% content_for :head do %>
+  <%# diff2html CSS dependencies - only loaded on sessions#show %>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/diff2html@3.4.47/bundles/css/diff2html.min.css">
+<% end %>
+
 <%= turbo_stream_from "session_#{@session.id}" %>
 
 <div id="session_redirect"></div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -68,7 +68,7 @@
         <!-- Git Status Display -->
         <% if @session.active? && @git_statuses&.any? %>
           <div class="h-10 w-px bg-gray-300 dark:bg-gray-600"></div>
-          <div class="flex items-center" data-controller="git-status">
+          <div class="flex items-center" data-controller="git-status git-diff-modal">
             <div class="relative group" data-controller="dropdown-hover" data-dropdown-hover-has-items-value="true">
               <!-- Compact summary button -->
               <button class="flex items-center space-x-2 px-3 py-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200"
@@ -122,7 +122,13 @@
                       </div>
                       
                       <% statuses.each do |status| %>
-                        <div class="flex items-start justify-between py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700 -mx-2 px-2 rounded transition-colors duration-150">
+                        <div class="flex items-start justify-between py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700 -mx-2 px-2 rounded transition-colors duration-150 <%= status[:has_changes] ? 'cursor-pointer' : '' %>"
+                             <% if status[:has_changes] %>
+                               data-action="click->git-diff-modal#open"
+                               data-directory="<%= status[:directory] %>"
+                               data-instance-name="<%= instance_name %>"
+                               data-session-id="<%= @session.id %>"
+                             <% end %>>
                           <div class="flex-1">
                             <!-- Directory path -->
                             <div class="flex items-center space-x-2 mb-1">
@@ -213,6 +219,44 @@
                       </div>
                     </div>
                   <% end %>
+                </div>
+              </div>
+            </div>
+            
+            <!-- Git Diff Modal -->
+            <div class="fixed inset-0 z-50 hidden" data-git-diff-modal-target="modal">
+              <div class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-75 transition-opacity"></div>
+              
+              <div class="fixed inset-0 z-50 overflow-y-auto">
+                <div class="flex min-h-full items-center justify-center p-4">
+                  <div class="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 text-left shadow-xl transition-all w-full max-w-7xl">
+                    <!-- Modal header -->
+                    <div class="bg-gray-50 dark:bg-gray-900 px-4 py-3 flex items-center justify-between">
+                      <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">Git Changes</h3>
+                      <button type="button" 
+                              class="rounded-md bg-transparent text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none"
+                              data-action="click->git-diff-modal#close">
+                        <%= heroicon "x-mark", variant: :outline, options: { class: "h-6 w-6" } %>
+                      </button>
+                    </div>
+                    
+                    <!-- Modal content -->
+                    <div class="max-h-[80vh] overflow-y-auto">
+                      <!-- Loading indicator -->
+                      <div class="p-8 text-center" data-git-diff-modal-target="loading">
+                        <div class="inline-flex items-center">
+                          <svg class="animate-spin h-8 w-8 text-orange-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                          </svg>
+                          <span class="ml-3 text-gray-600 dark:text-gray-400">Loading diff...</span>
+                        </div>
+                      </div>
+                      
+                      <!-- Diff content -->
+                      <div data-git-diff-modal-target="content"></div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/bin/install
+++ b/bin/install
@@ -58,6 +58,7 @@ echo "  • ttyd              - Terminal emulator for web access"
 echo "  • tmux              - Terminal multiplexer"
 echo "  • gh CLI            - GitHub command line interface"
 echo "  • gh webhook ext    - GitHub webhook extension"
+echo "  • diff2html-cli     - Diff to HTML converter (npm package)"
 echo "  • Container runtime - Podman or Docker (Podman will be installed if neither is present)"
 echo
 echo "Platform: $OS ($ARCH)"
@@ -100,6 +101,22 @@ install_macos() {
     brew install gh
   else
     echo "GitHub CLI is already installed"
+  fi
+
+  # Check for Node.js/npm
+  if ! command_exists npm; then
+    echo "Installing Node.js (for npm)..."
+    brew install node
+  else
+    echo "npm is already installed"
+  fi
+
+  # Install diff2html-cli
+  if ! command_exists diff2html; then
+    echo "Installing diff2html-cli..."
+    npm install -g diff2html-cli
+  else
+    echo "diff2html-cli is already installed"
   fi
 
   # Check for container runtime (Docker or Podman)
@@ -196,6 +213,30 @@ install_linux() {
     fi
   else
     echo "GitHub CLI is already installed"
+  fi
+
+  # Check for Node.js/npm
+  if ! command_exists npm; then
+    echo "Installing Node.js (for npm)..."
+    if [ "$PKG_MANAGER" = "apt-get" ]; then
+      # Install Node.js from NodeSource repository for Debian/Ubuntu
+      curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+      sudo apt-get install -y nodejs
+    elif [ "$PKG_MANAGER" = "yum" ] || [ "$PKG_MANAGER" = "dnf" ]; then
+      # Install Node.js from NodeSource repository for RHEL/CentOS/Fedora
+      curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash -
+      eval $PKG_INSTALL nodejs
+    fi
+  else
+    echo "npm is already installed"
+  fi
+
+  # Install diff2html-cli
+  if ! command_exists diff2html; then
+    echo "Installing diff2html-cli..."
+    npm install -g diff2html-cli
+  else
+    echo "diff2html-cli is already installed"
   fi
 
   # Check for container runtime (Docker or Podman)
@@ -299,6 +340,7 @@ command_exists ttyd && echo "✓ ttyd $(ttyd --version 2>&1 | head -n1)"
 command_exists tmux && echo "✓ tmux $(tmux -V)"
 command_exists gh && echo "✓ gh $(gh --version | head -n1)"
 gh extension list | grep -q "cli/gh-webhook" && echo "✓ gh webhook extension"
+command_exists diff2html && echo "✓ diff2html-cli $(diff2html --version 2>&1)"
 
 # Show container runtime status
 if command_exists docker; then

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       get :log_stream
       get :instances
       get :clone
+      post :git_diff
     end
   end
 


### PR DESCRIPTION
## Summary
- Added a modal to view git diffs when clicking on repositories with uncommitted changes in the navbar
- Integrated `diff2html-cli` to generate beautiful side-by-side diffs with syntax highlighting
- Added dark mode support for the diff viewer

## Changes
- **Dependencies**: Added `diff2html-cli` to the install script
- **Frontend**: Created a Stimulus controller to manage the git diff modal
- **Backend**: Added endpoint to generate diff HTML using diff2html
- **UI**: Made git status dropdown items clickable when they have changes
- **Styling**: Added diff2html CSS dependencies and dark mode overrides

## Test plan
1. Start a session with uncommitted changes in one or more repositories
2. Click on the git status indicator in the navbar
3. Click on any repository that shows changes (staged, modified, or untracked)
4. Verify that a modal opens showing the git diff
5. Test the close button (X) to dismiss the modal
6. Test in both light and dark modes

🤖 Generated with [Claude Code](https://claude.ai/code)