### PR TITLE
Add app URL to enable Ctrl+T

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -33,4 +33,6 @@ commands:
     aliases: ["s"]
     desc: 'start the server'
     run: PORT=4269 TTYD_PORT=4268 bin/start
-  
+
+open:
+  app: http://localhost:4269


### PR DESCRIPTION
Adding this config allows the use of Ctrl+T to open the app in the browser when running the server via `dev server`.