### PR TITLE
Fixes broken test on main

### DIFF
--- a/test/services/background_session_service_test.rb
+++ b/test/services/background_session_service_test.rb
@@ -105,7 +105,7 @@ class BackgroundSessionServiceTest < ActiveSupport::TestCase
 
     prompt = session.initial_prompt
     assert_match(/Issue #100/, prompt)
-    assert_match(%r{Repository: test/repo}, prompt)
+    assert_match(%r{test/repo repository}, prompt)
     assert_match(/@octocat/, prompt)
     assert_match(/Fix this/, prompt)
   end


### PR DESCRIPTION
Message changed so regex is failing. Small change. Questionable if it should include the "repository" part of the phrase, but I kept it. 